### PR TITLE
Add binary operator constructors to Relation class

### DIFF
--- a/app/infra/relation.py
+++ b/app/infra/relation.py
@@ -155,7 +155,9 @@ class Expression(ABC):
             return value
         if isinstance(value, (int, float, np.integer, np.floating)):
             return Literal(value.item() if hasattr(value, "item") else value)
-        return value
+        raise TypeError(
+            f"Unsupported operand type for Expression: {type(value).__name__}"
+        )
 
     def _binary_op(self, other: Any, operator: Operator) -> "BinaryExpression":
         return BinaryExpression(self, operator, self._coerce_operand(other))
@@ -200,14 +202,33 @@ class Expression(ABC):
         return self._binary_op(other, Operator.GREATER_THAN)
 
     def __eq__(self, other: Any):
-        if isinstance(other, Expression):
-            return self._binary_op(other, Operator.EQUAL)
-        return NotImplemented
+        return self._binary_op(other, Operator.EQUAL)
 
     def __ne__(self, other: Any):
-        if isinstance(other, Expression):
-            return self._binary_op(other, Operator.NOT_EQUAL)
-        return NotImplemented
+        return self._binary_op(other, Operator.NOT_EQUAL)
+
+    def __bool__(self) -> bool:
+        """
+        Prevent symbolic expressions from being used as booleans.
+
+        Expression comparisons build expression trees rather than yielding
+        concrete truth values, so boolean evaluation in Python conditionals
+        would otherwise silently behave as always truthy.
+        """
+        raise TypeError(
+            "Expression objects cannot be used as booleans. "
+            "Build relations with comparison operators and pass them to the "
+            "model, rather than using them in Python conditionals."
+        )
+
+    def __len__(self) -> int:
+        """
+        Prevent truth-value testing from falling back to __len__.
+        """
+        raise TypeError(
+            "Expression objects have no truth value. "
+            "Do not use symbolic expressions in boolean contexts."
+        )
 
     __hash__ = object.__hash__
 

--- a/app/infra/relation.py
+++ b/app/infra/relation.py
@@ -936,4 +936,3 @@ class Relation:
 
     def __str__(self):
         return f"[{self.name}] {self.expression}"
-

--- a/app/infra/relation.py
+++ b/app/infra/relation.py
@@ -936,3 +936,4 @@ class Relation:
 
     def __str__(self):
         return f"[{self.name}] {self.expression}"
+

--- a/app/infra/relation.py
+++ b/app/infra/relation.py
@@ -149,6 +149,68 @@ class Expression(ABC):
         """
         pass
 
+    @staticmethod
+    def _coerce_operand(value: Any) -> "Expression":
+        if isinstance(value, Expression):
+            return value
+        if isinstance(value, (int, float, np.integer, np.floating)):
+            return Literal(value.item() if hasattr(value, "item") else value)
+        return value
+
+    def _binary_op(self, other: Any, operator: Operator) -> "BinaryExpression":
+        return BinaryExpression(self, operator, self._coerce_operand(other))
+
+    def _rbinary_op(self, other: Any, operator: Operator) -> "BinaryExpression":
+        return BinaryExpression(self._coerce_operand(other), operator, self)
+
+    def __add__(self, other: Any):
+        return self._binary_op(other, Operator.ADD)
+
+    def __radd__(self, other: Any):
+        return self._rbinary_op(other, Operator.ADD)
+
+    def __sub__(self, other: Any):
+        return self._binary_op(other, Operator.SUBTRACT)
+
+    def __rsub__(self, other: Any):
+        return self._rbinary_op(other, Operator.SUBTRACT)
+
+    def __mul__(self, other: Any):
+        return self._binary_op(other, Operator.MULTIPLY)
+
+    def __rmul__(self, other: Any):
+        return self._rbinary_op(other, Operator.MULTIPLY)
+
+    def __truediv__(self, other: Any):
+        return self._binary_op(other, Operator.DIVIDE)
+
+    def __rtruediv__(self, other: Any):
+        return self._rbinary_op(other, Operator.DIVIDE)
+
+    def __le__(self, other: Any):
+        return self._binary_op(other, Operator.LESS_THAN_OR_EQUAL)
+
+    def __ge__(self, other: Any):
+        return self._binary_op(other, Operator.GREATER_THAN_OR_EQUAL)
+
+    def __lt__(self, other: Any):
+        return self._binary_op(other, Operator.LESS_THAN)
+
+    def __gt__(self, other: Any):
+        return self._binary_op(other, Operator.GREATER_THAN)
+
+    def __eq__(self, other: Any):
+        if isinstance(other, Expression):
+            return self._binary_op(other, Operator.EQUAL)
+        return NotImplemented
+
+    def __ne__(self, other: Any):
+        if isinstance(other, Expression):
+            return self._binary_op(other, Operator.NOT_EQUAL)
+        return NotImplemented
+
+    __hash__ = object.__hash__
+
 
 class Literal(Expression):
     """
@@ -775,13 +837,19 @@ class AssignmentExpression(Expression):
 
 
 class Relation:
-    def __init__(self, raw_expr: str, name: str = None):
-        self.raw_expr = raw_expr.strip()
+    def __init__(self, raw_expr: Union[str, Expression], name: str = None):
         self.name = name if name else f"{uuid.uuid4().hex}"
-        self.expression = self.parse(self.raw_expr)
+        if isinstance(raw_expr, Expression):
+            self.expression = raw_expr
+            self.raw_expr = str(raw_expr)
+        else:
+            self.raw_expr = raw_expr.strip()
+            self.expression = self.parse(self.raw_expr)
 
-    def parse(self, expr: str) -> Expression:
+    def parse(self, expr: Union[str, Expression]) -> Expression:
         """Parse the expression string into an Expression tree"""
+        if isinstance(expr, Expression):
+            return expr
         # For special expressions, handle them separately
         if expr.startswith("if"):
             return self._parse_if_then(expr)

--- a/app/infra/relation.py
+++ b/app/infra/relation.py
@@ -868,7 +868,7 @@ class Relation:
             self.expression = self.parse(self.raw_expr)
 
     def parse(self, expr: Union[str, Expression]) -> Expression:
-        """Parse the expression string into an Expression tree"""
+        """Parse a string expression into an Expression tree, or return an Expression input unchanged."""
         if isinstance(expr, Expression):
             return expr
         # For special expressions, handle them separately

--- a/test/test_infra/test_relation.py
+++ b/test/test_infra/test_relation.py
@@ -1,4 +1,5 @@
 import unittest.mock
+from typing import cast
 
 import pandas as pd
 
@@ -201,8 +202,9 @@ class TestBinaryExpressionParsing(unittest.TestCase):
     def test_parse_arithmetic_expression(self):
         """Test parsing arithmetic expressions"""
         expr = BinaryExpression.parse_binary("battery1.charging_power < 2 * pv1.power")
-
         self.assertIsInstance(expr, BinaryExpression)
+        expr = cast(BinaryExpression, expr)
+
         self.assertEqual(expr.operator, Operator.LESS_THAN)
 
         # Left side should be entity reference
@@ -222,8 +224,9 @@ class TestBinaryExpressionParsing(unittest.TestCase):
         expr = BinaryExpression.parse_binary(
             "battery1.discharge_power(t) < 2 * battery1.discharge_power(t-1)"
         )
-
         self.assertIsInstance(expr, BinaryExpression)
+        expr = cast(BinaryExpression, expr)
+
         self.assertEqual(expr.operator, Operator.LESS_THAN)
 
         # Left side: battery1.discharge_power(t)
@@ -243,8 +246,9 @@ class TestBinaryExpressionParsing(unittest.TestCase):
         expr = BinaryExpression.parse_binary(
             "battery.state_of_charge(t) >= battery.state_of_charge(t-1) + 0.1"
         )
-
         self.assertIsInstance(expr, BinaryExpression)
+        expr = cast(BinaryExpression, expr)
+
         self.assertEqual(expr.operator, Operator.GREATER_THAN_OR_EQUAL)
 
         # Left side: battery.state_of_charge(t)
@@ -261,6 +265,8 @@ class TestBinaryExpressionParsing(unittest.TestCase):
     def test_operator_precedence(self):
         """Test that multiplication has higher precedence than addition"""
         expr = BinaryExpression.parse_binary("x + 2 * y")
+        self.assertIsInstance(expr, BinaryExpression)
+        expr = cast(BinaryExpression, expr)
 
         # Should parse as: x + (2 * y)
         # Our parser finds the rightmost + first, then handles * in the right side
@@ -341,6 +347,29 @@ class TestRelation(unittest.TestCase):
         self.assertEqual(relation.expression.target, "heater2.min_on_duration")
         self.assertEqual(relation.expression.value, "2h")
 
+    def test_relation_accepts_expression_instance(self):
+        expr = BinaryExpression(
+            EntityReference("battery1.power"), Operator.LESS_THAN_OR_EQUAL, Literal(100)
+        )
+        relation = Relation(expr, "programmatic")
+
+        self.assertIs(relation.expression, expr)
+        self.assertEqual(relation.raw_expr, str(expr))
+        self.assertEqual(str(relation), f"[programmatic] {expr}")
+
+    def test_relation_if_then_expression_from_objects(self):
+        expr = IfThenExpression(
+            BinaryExpression(
+                EntityReference("battery1.power"), Operator.LESS_THAN, Literal(0)
+            ),
+            AssignmentExpression(EntityReference("battery1.output"), Literal(2)),
+        )
+        relation = Relation(expr, "conditional_programmatic")
+
+        self.assertIs(relation.expression, expr)
+        self.assertIsInstance(relation.expression.condition, BinaryExpression)
+        self.assertIsInstance(relation.expression.consequence, AssignmentExpression)
+
 
 class TestAdditionalRelationCases(unittest.TestCase):
     def test_entity_reference_invalid_id_raises(self):
@@ -375,7 +404,7 @@ class TestAdditionalRelationCases(unittest.TestCase):
 
         conv = C()
         ref = EntityReference("some.device", -1)
-        res = ref.convert(conv, t=5, time_set=10)
+        res = ref.convert(conv, t=5, time_set=None)
         self.assertEqual(res, ("ent_conv", "some.device"))
         self.assertIs(conv.called[0], ref)
         self.assertEqual(conv.called[2], 5)
@@ -513,11 +542,11 @@ class TestAdditionalRelationCases(unittest.TestCase):
         conv = C()
         rel = Relation("a <= b", "deleg")
         objects = {"a": 1, "b": 2}
-        res = rel.convert(conv, objects, time_set=10)
+        res = rel.convert(conv, objects, time_set=None)
         self.assertEqual(res, {"converted": True})
         self.assertIs(conv.called[0], rel)
         self.assertEqual(conv.called[1], objects)
-        self.assertEqual(conv.called[2], 10)
+        self.assertEqual(conv.called[2], None)
 
 
 class TestSelfReferenceParsing(unittest.TestCase):
@@ -878,6 +907,8 @@ class TestBinaryExpressionParsingExtended(unittest.TestCase):
         }
         for symbol, expected_op in operators.items():
             expr = BinaryExpression.parse_binary(f"x {symbol} y")
+            self.assertIsInstance(expr, BinaryExpression)
+            expr = cast(BinaryExpression, expr)
             self.assertEqual(expr.operator, expected_op)
 
     def test_parse_nested_parentheses(self):

--- a/test/test_infra/test_relation.py
+++ b/test/test_infra/test_relation.py
@@ -182,6 +182,61 @@ class TestEntityReference(unittest.TestCase):
         self.assertEqual(ref.get_ids(), ["battery1.power"])
 
 
+class TestExpressionOperatorOverloads(unittest.TestCase):
+    def test_arithmetic_overloads_coerce_numeric_rhs_to_literal(self):
+        x = EntityReference("x")
+
+        cases = [
+            (x + 2, Operator.ADD),
+            (x - 2, Operator.SUBTRACT),
+            (x * 2, Operator.MULTIPLY),
+            (x / 2, Operator.DIVIDE),
+        ]
+
+        for expr, expected_op in cases:
+            self.assertIsInstance(expr, BinaryExpression)
+            self.assertEqual(expr.operator, expected_op)
+            self.assertIs(expr.left, x)
+            self.assertIsInstance(expr.right, Literal)
+            self.assertEqual(expr.right.value, 2)
+
+    def test_reverse_arithmetic_overloads_coerce_numeric_lhs_to_literal(self):
+        x = EntityReference("x")
+
+        cases = [
+            (2 + x, Operator.ADD),
+            (2 - x, Operator.SUBTRACT),
+            (2 * x, Operator.MULTIPLY),
+            (2 / x, Operator.DIVIDE),
+        ]
+
+        for expr, expected_op in cases:
+            self.assertIsInstance(expr, BinaryExpression)
+            self.assertEqual(expr.operator, expected_op)
+            self.assertIsInstance(expr.left, Literal)
+            self.assertEqual(expr.left.value, 2)
+            self.assertIs(expr.right, x)
+
+    def test_comparison_overloads_between_expressions(self):
+        x = EntityReference("x")
+        y = EntityReference("y")
+
+        cases = [
+            (x < y, Operator.LESS_THAN),
+            (x <= y, Operator.LESS_THAN_OR_EQUAL),
+            (x > y, Operator.GREATER_THAN),
+            (x >= y, Operator.GREATER_THAN_OR_EQUAL),
+            (x == y, Operator.EQUAL),
+            (x != y, Operator.NOT_EQUAL),
+        ]
+
+        for expr, expected_op in cases:
+            self.assertIsInstance(expr, BinaryExpression)
+            self.assertEqual(expr.operator, expected_op)
+            self.assertIs(expr.left, x)
+            self.assertIs(expr.right, y)
+
+
 class TestBinaryExpressionParsing(unittest.TestCase):
     def test_parse_simple_comparison(self):
         """Test parsing simple comparison expressions"""

--- a/test/test_infra/test_relation.py
+++ b/test/test_infra/test_relation.py
@@ -1067,5 +1067,131 @@ class TestIfThenExpression(unittest.TestCase):
             expr.convert(Mock(), t=0)
 
 
+class TestExpressionBooleanPrevention(unittest.TestCase):
+    """Test that Expression.__bool__ and __len__ prevent truthiness evaluation."""
+
+    def test_entity_reference_bool_raises_typeerror(self):
+        """Test that bool(EntityReference(...)) raises TypeError"""
+        expr = EntityReference("battery.power")
+        with self.assertRaises(TypeError) as context:
+            bool(expr)
+
+        self.assertIn("cannot be used as booleans", str(context.exception))
+
+    def test_self_reference_bool_raises_typeerror(self):
+        """Test that bool(SelfReference(...)) raises TypeError"""
+        expr = SelfReference("power")
+        with self.assertRaises(TypeError) as context:
+            bool(expr)
+
+        self.assertIn("cannot be used as booleans", str(context.exception))
+
+    def test_literal_bool_raises_typeerror(self):
+        """Test that bool(Literal(...)) raises TypeError"""
+        expr = Literal(42)
+        with self.assertRaises(TypeError) as context:
+            bool(expr)
+
+        self.assertIn("cannot be used as booleans", str(context.exception))
+
+    def test_binary_expression_bool_raises_typeerror(self):
+        """Test that bool(BinaryExpression(...)) raises TypeError"""
+        expr = EntityReference("x") + 5
+        with self.assertRaises(TypeError) as context:
+            bool(expr)
+
+        self.assertIn("cannot be used as booleans", str(context.exception))
+
+    def test_if_conditional_with_expression_raises_typeerror(self):
+        """Test that using expression in if statement raises TypeError"""
+        expr = EntityReference("x") > 5
+        with self.assertRaises(TypeError):
+            if expr:
+                pass
+
+    def test_entity_reference_len_raises_typeerror(self):
+        """Test that len(EntityReference(...)) raises TypeError"""
+        expr = EntityReference("battery.power")
+        with self.assertRaises(TypeError) as context:
+            len(expr)
+
+        self.assertIn("truth value", str(context.exception).lower())
+
+    def test_while_loop_with_expression_raises_typeerror(self):
+        """Test that using expression in while loop raises TypeError"""
+        expr = EntityReference("sensor.value")
+        with self.assertRaises(TypeError):
+            while expr:
+                break
+
+    def test_not_operator_with_expression_raises_typeerror(self):
+        """Test that 'not expression' raises TypeError"""
+        expr = EntityReference("flag")
+        with self.assertRaises(TypeError):
+            not expr
+
+    def test_and_operator_with_expression_raises_typeerror(self):
+        """Test that 'expression and ...' raises TypeError"""
+        expr = EntityReference("x")
+        with self.assertRaises(TypeError):
+            expr and True
+
+    def test_or_operator_with_expression_raises_typeerror(self):
+        """Test that 'expression or ...' raises TypeError"""
+        expr = EntityReference("x")
+        with self.assertRaises(TypeError):
+            expr or False
+
+    def test_comparison_result_also_raises_typeerror(self):
+        """Test that results of comparison operations also raise TypeError in boolean context"""
+        comparison_expr = EntityReference("x") < 10
+        with self.assertRaises(TypeError):
+            bool(comparison_expr)
+
+    def test_arithmetic_result_also_raises_typeerror(self):
+        """Test that results of arithmetic operations also raise TypeError in boolean context"""
+        arithmetic_expr = EntityReference("x") * 2 + 5
+        with self.assertRaises(TypeError):
+            bool(arithmetic_expr)
+
+    def test_assignment_expression_bool_raises_typeerror(self):
+        """Test that bool(AssignmentExpression(...)) raises TypeError"""
+        # AssignmentExpression is created via string parsing or direct instantiation
+        expr = AssignmentExpression(EntityReference("output"), Literal(2))
+        with self.assertRaises(TypeError):
+            bool(expr)
+
+    def test_if_then_expression_bool_raises_typeerror(self):
+        """Test that bool(IfThenExpression(...)) raises TypeError"""
+        condition = EntityReference("x") > 0
+        consequence = Literal(1)
+        expr = IfThenExpression(condition, consequence)
+        with self.assertRaises(TypeError):
+            bool(expr)
+
+    def test_bool_error_message_explains_issue(self):
+        """Test that __bool__ error message explains the issue and suggests solution"""
+        expr = EntityReference("power")
+        try:
+            bool(expr)
+            self.fail("Expected TypeError")
+        except TypeError as e:
+            error_msg = str(e)
+            # Verify the error message is informative
+            self.assertIn("Expression", error_msg)
+            self.assertIn("cannot be used as booleans", error_msg)
+
+    def test_len_error_message_explains_issue(self):
+        """Test that __len__ error message explains the issue"""
+        expr = EntityReference("power")
+        try:
+            len(expr)
+            self.fail("Expected TypeError")
+        except TypeError as e:
+            error_msg = str(e)
+            # Verify the error message is informative
+            self.assertIn("truth value", error_msg.lower())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces operator overloading to the `Expression` class, allowing for more natural and Pythonic construction of expression trees using standard arithmetic and comparison operators. It also enhances the `Relation` class to accept both string and `Expression` instances, and updates the tests to cover these new capabilities and improve type safety.

**Core expression system enhancements:**

* Added operator overloading methods (e.g., `__add__`, `__sub__`, `__mul__`, `__truediv__`, and all comparison operators) to the `Expression` class, enabling the use of Python operators to build expression trees directly (e.g., `expr1 + expr2` creates a `BinaryExpression`). (`app/infra/relation.py`, [app/infra/relation.pyR152-R213](diffhunk://#diff-8a66329bc02ffdf73350389080ce60d05e0a880db1a3928d9cb028cacaff162fR152-R213))
* Implemented the `_coerce_operand` helper in `Expression` to ensure that operands are properly wrapped as `Literal` or `Expression` types, supporting seamless operator use with Python numeric types. (`app/infra/relation.py`, [app/infra/relation.pyR152-R213](diffhunk://#diff-8a66329bc02ffdf73350389080ce60d05e0a880db1a3928d9cb028cacaff162fR152-R213))

**Relation class improvements:**

* Modified the `Relation` class to accept either a string or an `Expression` instance as its expression argument, updating initialization and parsing logic accordingly. (`app/infra/relation.py`, [app/infra/relation.pyL778-R852](diffhunk://#diff-8a66329bc02ffdf73350389080ce60d05e0a880db1a3928d9cb028cacaff162fL778-R852))

**Testing and type safety:**

* Updated and expanded tests to use `cast` for type safety, to verify correct operator precedence, and to ensure that `Relation` accepts `Expression` objects directly. Added tests for programmatic and conditional construction of `Relation` instances. (`test/test_infra/test_relation.py`, [[1]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dL204-R207) [[2]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dL225-R229) [[3]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dL246-R251) [[4]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dR268-R269) [[5]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dR350-R372) [[6]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dR910-R911)
* Adjusted test cases to pass `None` for `time_set` where appropriate, reflecting updated expectations for conversion methods. (`test/test_infra/test_relation.py`, [[1]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dL378-R407) [[2]](diffhunk://#diff-7708775855f8679cc82301124a8bda83f26fb91c062355636f1e8b857694941dL516-R549)