### PR TITLE
Fix renamed timeseries_object_factory in docs

### DIFF
--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -1,0 +1,2 @@
+"""Model entities and helpers for OMNES."""
+

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -1,2 +1,1 @@
 """Model entities and helpers for OMNES."""
-

--- a/app/model/device.py
+++ b/app/model/device.py
@@ -1,3 +1,5 @@
+"""Base device types shared by model entities."""
+
 from enum import Enum
 from typing import Optional
 
@@ -16,6 +18,15 @@ class Vector(Enum):
 
 
 class Device(Entity):
+    """Base class for model devices attached to a bus.
+
+    Attributes:
+        default_vector: Default energy vector used for the device.
+        default_contributes_to: Default balance key the device contributes to.
+        bus: Bus identifier or bus entity assigned to the device.
+        tags: Free-form metadata tags, including vector information.
+    """
+
     _quantity_excludes = ["default_vector", "default_contributes_to"]
 
     default_vector: Optional[Vector] = Vector.INVALID

--- a/app/model/generator/generator.py
+++ b/app/model/generator/generator.py
@@ -1,3 +1,5 @@
+"""Generator base class for production devices."""
+
 from typing import Optional
 
 from app.infra.parameter import Parameter
@@ -10,6 +12,19 @@ from app.model.device import Device, Vector
 
 
 class Generator(Device):
+    """Base class for devices that produce electrical power.
+
+    Attributes:
+        default_vector: Default energy vector used by the generator.
+        default_contributes_to: Default balance key the generator contributes to.
+        default_peak_power: Default peak power rating.
+        default_efficiency: Default efficiency.
+        p_out: Active power output time series.
+        q_out: Reactive power output time series.
+        peak_power: Peak power rating.
+        efficiency: Conversion efficiency.
+    """
+
     default_vector = Vector.ELECTRICITY
     default_contributes_to = "electric_power_balance"
     default_peak_power = 0

--- a/app/model/generator/pv.py
+++ b/app/model/generator/pv.py
@@ -1,3 +1,5 @@
+"""Photovoltaic generator model."""
+
 from typing import Optional
 
 from app.infra.quantity_factory import (
@@ -8,6 +10,13 @@ from app.model.generator.generator import Generator
 
 
 class PV(Generator):
+    """Photovoltaic generator.
+
+    Attributes:
+        p_out: Active power output time series.
+        q_out: Reactive power output time series.
+    """
+
     def __init__(
         self,
         id: Optional[str] = None,

--- a/app/model/generator/wind_turbine.py
+++ b/app/model/generator/wind_turbine.py
@@ -1,3 +1,5 @@
+"""Wind turbine generator model."""
+
 from typing import Optional
 
 from app.infra.quantity_factory import (
@@ -8,6 +10,13 @@ from app.model.generator.generator import Generator
 
 
 class Wind(Generator):
+    """Wind turbine generator.
+
+    Attributes:
+        p_out: Active power output time series.
+        q_out: Reactive power output time series.
+    """
+
     def __init__(
         self,
         id: Optional[str] = None,

--- a/app/model/grid_component/bus.py
+++ b/app/model/grid_component/bus.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class BusType(Enum):
+    """Bus classification used for power-flow calculations."""
+
     PQ = "PQ"
     I = "I"
     Z = "Z"
@@ -21,6 +23,16 @@ class BusType(Enum):
 
 
 class Bus(GridComponent):
+    """Electrical bus node in the grid.
+
+    Attributes:
+        default_nominal_voltage: Default nominal voltage.
+        default_type: Default bus type.
+        voltage: Bus voltage time series.
+        nominal_voltage: Nominal bus voltage.
+        type: Bus classification.
+    """
+
     _quantity_excludes = ["default_type"]
     default_nominal_voltage: Optional[float] = None
     default_type: Optional[BusType] = BusType.PQ.value

--- a/app/model/grid_component/connector.py
+++ b/app/model/grid_component/connector.py
@@ -8,6 +8,13 @@ from app.model.grid_component.grid_component import GridComponent
 
 
 class Connector(GridComponent):
+    """Grid component that connects two buses.
+
+    Attributes:
+        from_bus: Source bus identifier or bus entity.
+        to_bus: Target bus identifier or bus entity.
+    """
+
     def __init__(
         self,
         id: Optional[str] = None,

--- a/app/model/grid_component/grid_component.py
+++ b/app/model/grid_component/grid_component.py
@@ -1,3 +1,5 @@
+"""Grid component base class for buses, lines and transformers."""
+
 from typing import Optional
 
 from app.infra.quantity_factory import (

--- a/app/model/grid_component/line.py
+++ b/app/model/grid_component/line.py
@@ -10,6 +10,22 @@ from app.model.grid_component.connector import Connector
 
 
 class Line(Connector):
+    """Transmission or distribution line between two buses.
+
+    Attributes:
+        default_line_length: Default physical length of the line.
+        default_resistance: Default series resistance.
+        default_reactance: Default series reactance.
+        default_max_current: Default current limit.
+        default_capacitance: Default shunt capacitance.
+        current: Line current time series.
+        line_length: Physical line length.
+        resistance: Series resistance.
+        reactance: Series reactance.
+        max_current: Current limit.
+        capacitance: Shunt capacitance.
+    """
+
     default_line_length: Optional[float] = None
     default_resistance: Optional[float] = None
     default_reactance: Optional[float] = None

--- a/app/model/load/load.py
+++ b/app/model/load/load.py
@@ -1,3 +1,5 @@
+"""Load model for electricity consumption devices."""
+
 from typing import Optional
 
 from app.infra.parameter import Parameter
@@ -10,6 +12,16 @@ from app.model.device import Device, Vector
 
 
 class Load(Device):
+    """Electric load that consumes active and reactive power.
+
+    Attributes:
+        default_vector: Default energy vector used by the load.
+        default_contributes_to: Default balance key the load contributes to.
+        p_cons: Active power consumption time series.
+        q_cons: Reactive power consumption time series.
+        nominal_power: Rated power of the load.
+    """
+
     default_vector = Vector.ELECTRICITY
     default_contributes_to = "electric_power_balance"
 

--- a/app/model/model.py
+++ b/app/model/model.py
@@ -1,3 +1,5 @@
+"""Top-level model container and build helpers."""
+
 import secrets
 from typing import Optional
 

--- a/app/model/slack.py
+++ b/app/model/slack.py
@@ -1,3 +1,5 @@
+"""Slack device model used for balancing power flows."""
+
 from typing import Optional
 
 from app.infra.quantity_factory import (
@@ -9,6 +11,13 @@ from app.model.device import Device
 
 
 class Slack(Device):
+    """Balancing device that tracks net in- and out-flow.
+
+    Attributes:
+        p_in: Incoming power time series.
+        p_out: Outgoing power time series.
+    """
+
     def __init__(
         self,
         id: Optional[str] = None,

--- a/app/model/storage/battery.py
+++ b/app/model/storage/battery.py
@@ -1,3 +1,5 @@
+"""Battery storage model."""
+
 from typing import Optional
 
 from ...infra.quantity_factory import (
@@ -9,6 +11,13 @@ from .storage import Storage
 
 
 class Battery(Storage):
+    """Battery storage device for electrical energy.
+
+    Attributes:
+        default_vector: Default energy vector used by the battery.
+        default_contributes_to: Default balance key the battery contributes to.
+    """
+
     default_vector = Vector.ELECTRICITY
     default_contributes_to = "electric_power_balance"
 

--- a/app/model/storage/hot_water_storage.py
+++ b/app/model/storage/hot_water_storage.py
@@ -1,3 +1,5 @@
+"""Hot water storage model for thermal energy buffering."""
+
 from typing import Optional
 
 from app.infra.parameter import Parameter

--- a/app/model/storage/storage.py
+++ b/app/model/storage/storage.py
@@ -1,3 +1,5 @@
+"""Storage base class for buffered energy devices."""
+
 from typing import Optional
 
 from app.infra.parameter import Parameter
@@ -11,6 +13,21 @@ from app.model.device import Device
 
 
 class Storage(Device):
+    """Base class for devices that store and release energy.
+
+    Attributes:
+        default_capacity: Default storage capacity.
+        default_max_charge_rate: Default charging rate.
+        default_max_discharge_rate: Default discharging rate.
+        default_charge_efficiency: Default charging efficiency.
+        default_discharge_efficiency: Default discharging efficiency.
+        default_storage_efficiency: Default overall storage efficiency.
+        default_state_of_charge: Default state of charge.
+        p_in: Charging power time series.
+        p_out: Discharging power time series.
+        e_stor: Stored energy time series.
+    """
+
     # These default members are initialized via an overloaded '=' operator,
     # so their effective runtime type is Quantity even when assigned scalar defaults.
     default_capacity: Optional[Quantity] = None

--- a/app/model/transducer/transducer.py
+++ b/app/model/transducer/transducer.py
@@ -1,3 +1,5 @@
+"""Energy transducer model for coupled input and output devices."""
+
 from typing import Optional
 
 from app.infra.parameter import Parameter
@@ -10,6 +12,19 @@ from app.model.device import Device
 
 
 class Transducer(Device):
+    """Device that converts power between an input and output device.
+
+    Attributes:
+        default_conversion_efficiency: Default conversion efficiency.
+        default_controllable: Whether the transducer is controllable by default.
+        input_device: Source device identifier or device instance.
+        output_device: Target device identifier or device instance.
+        p_in: Input power time series.
+        p_out: Output power time series.
+        controllable: Control flag time series.
+        conversion_efficiency: Conversion efficiency parameter.
+    """
+
     default_conversion_efficiency: Optional[float] = None
     default_controllable = True
 

--- a/app/model/util.py
+++ b/app/model/util.py
@@ -23,11 +23,9 @@ def create_default_quantity(value):
 
 
 class InitializingMeta(type):
-    """
-    Metaclass that converts default_ class members into Parameter/TimeseriesObject
-    at class creation time. Does not interfere with instance initialization.
+    """Metaclass that converts default_ class attributes into quantities.
 
-    Fields listed in _quantity_excludes are left as plain values.
+    Attributes named in ``_quantity_excludes`` are left unchanged.
     """
 
     def __new__(mcs, name, bases, namespace):

--- a/docs/infra/quantity_factory.md
+++ b/docs/infra/quantity_factory.md
@@ -1,4 +1,4 @@
-::: app.infra.timeseries_object_factory
+::: app.infra.quantity_factory
     options:
         show_root_heading: true
         show_source: false


### PR DESCRIPTION
This pull request updates documentation to reflect a rename of the factory component from `timeseries_object_factory` to `quantity_factory`.

- Documentation update:
  * Renamed the file `docs/infra/timeseries_object_factory.md` to `docs/infra/quantity_factory.md` and updated the root heading to match the new factory name.